### PR TITLE
Add Debug impl to error primitive

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -102,6 +102,7 @@ mod sys {
     }
 }
 
+#[derive(Debug)]
 pub struct Error;
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
Without this implementation, neither `unwrap` nor `expect` are usable with any `Result` type containing the `Error`.