### PR TITLE
Enable const generics feature for bytemuck dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytemuck = { version = "1.9.1", features = ["derive"] }
+bytemuck = { version = "1.9.1", features = ["derive", "min_const_generics"] }
 time = { version = "0.3.5", default-features = false }


### PR DESCRIPTION
This makes working with arrays way easier as it implements `Pod` over generic array lengths.