### PR TITLE
Support Floating Point Number Formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,13 @@ asr-derive = { path = "asr-derive", optional = true }
 bytemuck = { version = "1.9.1", features = ["derive", "min_const_generics"] }
 itoa = { version = "1.0.1", default-features = false, optional = true }
 memchr = { version = "2.5.0", default-features = false, optional = true }
+ryu = { version = "1.0.11", default-features = false, optional = true }
 time = { version = "0.3.5", default-features = false }
 
 [features]
 integer-vars = ["itoa"]
+float-vars = ["ryu"]
+float-vars-small = ["float-vars", "ryu/small"]
 gba = []
 signature = ["memchr"]
 derive = ["asr-derive"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,9 @@ pub use time;
 
 #[cfg(feature = "derive")]
 pub use asr_derive::Settings;
+
+#[cfg(feature = "itoa")]
+pub use itoa;
+
+#[cfg(feature = "ryu")]
+pub use ryu;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -317,6 +317,12 @@ pub mod timer {
         let mut buf = itoa::Buffer::new();
         set_variable(key, buf.format(value));
     }
+
+    #[cfg(feature = "float-vars")]
+    pub fn set_variable_float(key: &str, value: impl ryu::Float) {
+        let mut buf = ryu::Buffer::new();
+        set_variable(key, buf.format(value));
+    }
 }
 
 pub mod user_settings {


### PR DESCRIPTION
Auto Splitters written in Rust tend to be a lot smaller when not using `std` or even `core::fmt`. Using crates that directly format numbers results in much smaller binaries. We previously added the `itoa` crate for formatting integers. This brings in `ryu` which is almost identical, but works on floating point numbers. However by default it brings in a fairly large lookup table, so there's an alterntive feature that can be activated to trade off size for speed.